### PR TITLE
Padronizando informacoes de log do Castalia-trace

### DIFF
--- a/Castalia-K/src/node/application/throughputBinomial/ThroughputBinomial.cc
+++ b/Castalia-K/src/node/application/throughputBinomial/ThroughputBinomial.cc
@@ -187,9 +187,9 @@ int ThroughputBinomial::handleControlCommand(cMessage * msg){
 	switch (INFO_TYPE) {
 		
 		case TAXAMAC_INFO : {
-			trace() << "RANDOMICO    " << nroRandomico << "    POTENCIA    " << potencia;
+			trace() << "POTENCIA_INFO" << potencia  << "    RANDOMICO    " << nroRandomico;
 			trace() << "TAXAMAC_INFO    " << cmd->getTaxaMAC() << "    BUFFER_INFO    " << cmd->getBufferState();
-
+            
 			potenciaAtual = potencia;
 			toNetworkLayer(createRadioCommand(SET_TX_OUTPUT,potencia));	
 			break;	

--- a/Castalia-K/src/node/application/throughputBufferAware/ThroughputBufferAware.cc
+++ b/Castalia-K/src/node/application/throughputBufferAware/ThroughputBufferAware.cc
@@ -243,8 +243,8 @@ int ThroughputBufferAware::handleControlCommand(cMessage * msg){
 			{
 				varyPowerTransmissionByBufferState(state);
 			}
-			trace() << "BUFFER_INFO    " << state << "    POTENCIA    " << potenciaAtual << "    IS_TAXA_BUFFER    " << utilizarTaxaBuffer;
-			
+			trace() << "BUFFER_INFO    " << state << "    IS_TAXA_BUFFER    " << utilizarTaxaBuffer;
+			trace() << "POTENCIA_INFO    " << potenciaAtual ;
 		}
 	}
 

--- a/Castalia-K/src/node/application/throughputCL2/ThroughputCL2.cc
+++ b/Castalia-K/src/node/application/throughputCL2/ThroughputCL2.cc
@@ -242,14 +242,14 @@ int ThroughputCL2::handleControlCommand(cMessage * msg){
 //		trace() << "Chegou APP ";
 		CrossLayerMsg *cmd = check_and_cast <CrossLayerMsg*>(msg);
 		taxaMAC = cmd->getTaxaMAC();
-		trace() << "TAXA_MAC    "<<taxaMAC;
+		trace() << "TAXAMAC_INFO    "<< taxaMAC;
 
 		if (taxaMAC < taxa){
-			trace() << " Altera1 " << potencia1 << " TaxaMAC " << taxaMAC;
+			trace() << "POTENCIA_INFO " << potencia1 << " TAXA_MAC " << taxaMAC;
 			toNetworkLayer(createRadioCommand(SET_TX_OUTPUT,potencia1));
 			toNetworkLayer(createRadioCommand(SET_CCA_THRESHOLD,CCAthreshold2));
 		} else {
-			trace() << " Altera2 " << potencia2 << " TaxaMAC " << taxaMAC;
+			trace() << "POTENCIA_INFO " << potencia2 << " TAXA_MAC " << taxaMAC;
 			toNetworkLayer(createRadioCommand(SET_TX_OUTPUT,potencia2));
 			toNetworkLayer(createRadioCommand(SET_CCA_THRESHOLD,CCAthreshold));
 		}

--- a/Castalia-K/src/node/application/throughputCL4/ThroughputCL4.cc
+++ b/Castalia-K/src/node/application/throughputCL4/ThroughputCL4.cc
@@ -249,59 +249,59 @@ int ThroughputCL4::handleControlCommand(cMessage * msg){
 	if(atoi(SELF_NETWORK_ADDRESS)!=0){
 
 //		trace()<<"Packet Spacing " << packet_spacing << " Packet Rate " << packet_rate;
-		trace() << "Chegou APP ";
+
 		CrossLayerMsg *cmd = check_and_cast <CrossLayerMsg*>(msg);
 		taxaMAC = cmd->getTaxaMAC();
-		trace() << "TAXAMAC"<<taxaMAC;
+		trace() << "TAXAMAC_INFO    "<< taxaMAC;
 
 	
 // CONFIGURAÇÃO PARA O NÓ 1 e 2
 
 	if (taxaMAC <= 40 && ( (atoi(SELF_NETWORK_ADDRESS)==1) || (atoi(SELF_NETWORK_ADDRESS)==2) ) ) { 
-			trace() << " ALTERADO PARA POTENCIA1 " << potencia1;
+			trace() << "POTENCIA_INFO " << potencia1;
 			toNetworkLayer(createRadioCommand(SET_TX_OUTPUT,potencia1)); 
 			toNetworkLayer(createRadioCommand(SET_CCA_THRESHOLD,CCAthreshold2)); 
 		} 
 
 		else if (taxaMAC < 70 && (atoi(SELF_NETWORK_ADDRESS)==1 || (atoi(SELF_NETWORK_ADDRESS)==2)) ) {
-			trace() << " ALTERADO PARA POTENCIA2" << potencia2;
+			trace() << "POTENCIA_INFO" << potencia2;
 			toNetworkLayer(createRadioCommand(SET_TX_OUTPUT,potencia2));
 			toNetworkLayer(createRadioCommand(SET_CCA_THRESHOLD,CCAthreshold));
 		}
 
 		else if (taxaMAC < 90 && (atoi(SELF_NETWORK_ADDRESS)==1 || (atoi(SELF_NETWORK_ADDRESS)==2)) ) {
-			trace() << " ALTERADO PARA POTENCIA3" << potencia3;
+			trace() << "POTENCIA_INFO" << potencia3;
 			toNetworkLayer(createRadioCommand(SET_TX_OUTPUT,potencia3));
 			toNetworkLayer(createRadioCommand(SET_CCA_THRESHOLD,CCAthreshold));
 		}
 
 		else if (taxaMAC >= 90 && (atoi(SELF_NETWORK_ADDRESS)==1 || (atoi(SELF_NETWORK_ADDRESS)==2)) ){
-			trace() << " ALTERADO PARA POTENCIA4" << potencia4;
+			trace() << "POTENCIA_INFO" << potencia4;
 			toNetworkLayer(createRadioCommand(SET_TX_OUTPUT,potencia4));
 			toNetworkLayer(createRadioCommand(SET_CCA_THRESHOLD,CCAthreshold));
 		}
 // CONFIGURAÇÃO PARA O NÓ 3
 
 		else if ( taxaMAC <= 40 &&  (atoi(SELF_NETWORK_ADDRESS)==3) ) { 
-			trace() << " ALTERADO PARA POTENCIA1 " << potencia1;
+			trace() << "POTENCIA_INFO " << potencia1;
 			toNetworkLayer(createRadioCommand(SET_TX_OUTPUT,potencia1)); 
 			toNetworkLayer(createRadioCommand(SET_CCA_THRESHOLD,CCAthreshold2)); 
 		} 
 
 		else if (taxaMAC < 70 && (atoi(SELF_NETWORK_ADDRESS)==3) ) {
-			trace() << " ALTERADO PARA POTENCIA2" << potencia2;
+			trace() << "POTENCIA_INFO" << potencia2;
 			toNetworkLayer(createRadioCommand(SET_TX_OUTPUT,potencia2));
 			toNetworkLayer(createRadioCommand(SET_CCA_THRESHOLD,CCAthreshold));
 		}
 
 		else if (taxaMAC < 90 && (atoi(SELF_NETWORK_ADDRESS)==3 ) ) {
-			trace() << " ALTERADO PARA POTENCIA3" << potencia3;
+			trace() << "POTENCIA_INFO" << potencia3;
 			toNetworkLayer(createRadioCommand(SET_TX_OUTPUT,potencia3));
 			toNetworkLayer(createRadioCommand(SET_CCA_THRESHOLD,CCAthreshold));
 		}
 
 		else if (taxaMAC >= 90 && (atoi(SELF_NETWORK_ADDRESS)==3 )) {
-			trace() << " ALTERADO PARA POTENCIA4" << potencia4;
+			trace() << "POTENCIA_INFO" << potencia4;
 			toNetworkLayer(createRadioCommand(SET_TX_OUTPUT,potencia4));
 			toNetworkLayer(createRadioCommand(SET_CCA_THRESHOLD,CCAthreshold));
 		}
@@ -310,19 +310,11 @@ int ThroughputCL4::handleControlCommand(cMessage * msg){
 // CONFIGURAÇÃO PARA O NÓ 4 e 5
 
 		else if (taxaMAC <= 100 && ( (atoi(SELF_NETWORK_ADDRESS)==4) || (atoi(SELF_NETWORK_ADDRESS)==5) ) ) { 
-			trace() << " ALTERADO PARA POTENCIA4 " << potencia4;
+			trace() << "POTENCIA_INFO " << potencia4;
 			toNetworkLayer(createRadioCommand(SET_TX_OUTPUT,potencia1)); 
 			toNetworkLayer(createRadioCommand(SET_CCA_THRESHOLD,CCAthreshold2)); 
 		} 
-
 		
-	
-		if (cmd->getTaxaMAC() == 1 && packet_rate <= packet_rate_safe && packet_rate > 1){
-			packet_rate = packet_rate - 1;
-		} else if (cmd->getTaxaMAC() == 2 && packet_rate <= packet_rate_safe && packet_rate >= 0){
-			packet_rate = packet_rate + 1;
-		}
-//		
 		delete cmd;
 	}
 

--- a/Castalia-K/src/node/application/throughputPolicies/ThroughputPolicies.cc
+++ b/Castalia-K/src/node/application/throughputPolicies/ThroughputPolicies.cc
@@ -501,7 +501,8 @@ int ThroughputPolicies::handleControlCommand(cMessage * msg){
 		// funcao que varia a potencia
 		// varyPowerLevel(int noIndex, int nivelAnterior, int variacao)
 		int potencia = varyPowerLevel(indexNO, variacao);
-		trace() << "ALTERADO PARA POTENCIA  " << potencia << "  TAXA MAC  " << taxaMAC;
+		trace() << "POTENCIA_INFO   " << potencia;
+        trace() << "TAXAMAC_INFO    " << taxaMAC;
 		toNetworkLayer(createRadioCommand(SET_TX_OUTPUT,potencia));
 		vetorNivelMACNo[indexNO] = nivelClassificado;
 

--- a/Castalia-K/src/node/application/throughputStandard/ThroughputStandard.cc
+++ b/Castalia-K/src/node/application/throughputStandard/ThroughputStandard.cc
@@ -123,3 +123,16 @@ void ThroughputStandard::finishSpecific() {
 		collectOutput("Energy nJ/bit","",energy);
 	}
 }
+
+
+int ThroughputStandard::handleControlCommand(cMessage * msg){
+    
+    double taxaMAC = 0.0;
+
+    CrossLayerMsg *cmd = check_and_cast <CrossLayerMsg*>(msg);
+    taxaMAC = cmd->getTaxaMAC();
+    trace() << "TAXAMAC_INFO    "<< taxaMAC;
+
+    delete msg;
+    return 1;
+}

--- a/Castalia-K/src/node/application/throughputStandard/ThroughputStandard.h
+++ b/Castalia-K/src/node/application/throughputStandard/ThroughputStandard.h
@@ -14,6 +14,7 @@
 #define _THROUGHPUTTEST_H_
 
 #include "VirtualApplication.h"
+#include "CrossLayerMsg_m.h"
 #include <map>
 
 using namespace std;
@@ -44,6 +45,8 @@ class ThroughputStandard: public VirtualApplication {
 	void handleRadioControlMessage(RadioControlMessage *);
 	void timerFiredCallback(int);
 	void finishSpecific();
+
+    int handleControlCommand(cMessage *);
 
  public:
 	int getPacketsSent(int addr) { return packetsSent[addr]; }

--- a/Castalia-K/src/node/application/throughputTest/ThroughputTest.cc
+++ b/Castalia-K/src/node/application/throughputTest/ThroughputTest.cc
@@ -119,3 +119,15 @@ void ThroughputTest::finishSpecific() {
 		collectOutput("Energy nJ/bit","",energy);
 	}
 }
+
+int ThroughputTest::handleControlCommand(cMessage * msg){
+    
+    double taxaMAC = 0.0;
+
+    CrossLayerMsg *cmd = check_and_cast <CrossLayerMsg*>(msg);
+    taxaMAC = cmd->getTaxaMAC();
+    trace() << "TAXAMAC_INFO    "<< taxaMAC;
+
+    delete msg;
+    return 1;
+}

--- a/Castalia-K/src/node/application/throughputTest/ThroughputTest.h
+++ b/Castalia-K/src/node/application/throughputTest/ThroughputTest.h
@@ -14,6 +14,7 @@
 #define _THROUGHPUTTEST_H_
 
 #include "VirtualApplication.h"
+#include "CrossLayerMsg_m.h"
 #include <map>
 
 using namespace std;
@@ -44,6 +45,8 @@ class ThroughputTest: public VirtualApplication {
 	void handleRadioControlMessage(RadioControlMessage *);
 	void timerFiredCallback(int);
 	void finishSpecific();
+
+    int handleControlCommand(cMessage *);
 
  public:
 	int getPacketsSent(int addr) { return packetsSent[addr]; }

--- a/Castalia-K/src/node/application/throughputUniforme/ThroughputUniforme.cc
+++ b/Castalia-K/src/node/application/throughputUniforme/ThroughputUniforme.cc
@@ -187,7 +187,7 @@ int ThroughputUniforme::handleControlCommand(cMessage * msg){
 	switch (INFO_TYPE) {
 		
 		case TAXAMAC_INFO : {
-			trace() << "RANDOMICO    " << nroRandomico << "    POTENCIA    " << potencia;
+			trace() << "POTENCIA_INFO" << potencia  << "    RANDOMICO    " << nroRandomico;
 			trace() << "TAXAMAC_INFO    " << cmd->getTaxaMAC() << "    BUFFER_INFO    " << cmd->getBufferState();
 
 			potenciaAtual = potencia;


### PR DESCRIPTION
Padronizar informações para utilizar os mesmos arquivos awk.

 Mudanças a serem submetidas:
	modified:   src/node/application/throughputBinomial/ThroughputBinomial.cc
	modified:   src/node/application/throughputBufferAware/ThroughputBufferAware.cc
	modified:   src/node/application/throughputCL2/ThroughputCL2.cc
	modified:   src/node/application/throughputCL4/ThroughputCL4.cc
	modified:   src/node/application/throughputPolicies/ThroughputPolicies.cc
	modified:   src/node/application/throughputStandard/ThroughputStandard.cc
	modified:   src/node/application/throughputStandard/ThroughputStandard.h
	modified:   src/node/application/throughputTest/ThroughputTest.cc
	modified:   src/node/application/throughputTest/ThroughputTest.h
	modified:   src/node/application/throughputUniforme/ThroughputUniforme.cc